### PR TITLE
Remove entities

### DIFF
--- a/dodas.cpp
+++ b/dodas.cpp
@@ -330,7 +330,22 @@ int main(int argc, char** argv) {
             // debug << "\tBullet " << j << ": " << Bullet::bullets[j] << std::endl;
         }
         #endif
-        std::vector<std::vector<std::shared_ptr<Bullet>>::iterator> bulletsToRemoveByIt;
+        Bullet::bullets.erase(
+            std::remove_if(
+                Bullet::bullets.begin(),
+                Bullet::bullets.end(),
+                [](const std::shared_ptr<Bullet>& bullet) {
+                    if (!bullet) return true;
+                    if (bullet->collided) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(bullet.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            Bullet::bullets.end()
+        );
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bullet::bullets);
         for (unsigned j=0; j<Bullet::bullets.size(); j++) {
             if (j >= Bullet::bullets.size()) break;
@@ -338,55 +353,70 @@ int main(int argc, char** argv) {
             std::shared_ptr<Bullet> bullet = Bullet::bullets[j];
             if (bullet == nullptr) continue;
             // debug << "\t\tNot nullptr " << bullet << std::endl;
-            if (bullet->collided) {
-                // debug << "\t\tCollided" << std::endl;
-                bulletsToRemoveByIt.push_back(std::find(Bullet::bullets.begin(), Bullet::bullets.end(), bullet));
-                continue;
-            }
+            if (bullet->collided) continue;
             // debug << "\t\tNot collided" << std::endl;
             bullet->move();
             // debug << "\t\tAfter move" << std::endl;
         }
+        Bullet::bullets.erase(
+            std::remove_if(
+                Bullet::bullets.begin(),
+                Bullet::bullets.end(),
+                [](const std::shared_ptr<Bullet>& bullet) {
+                    if (!bullet) return true;
+                    if (bullet->collided) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(bullet.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            Bullet::bullets.end()
+        );
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bullet::bullets);
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)EnemyBullet::enemyBullets);
         // debug << "\tAfter bullets" << std::endl;
-        std::vector<std::vector<std::shared_ptr<EnemyBullet>>::iterator> enemyBulletsToRemoveByIt;
-        for (auto enemyBullet : EnemyBullet::enemyBullets) {
-            // if (enemyBullet == nullptr) continue;
-            if (enemyBullet->collided) {
-                enemyBulletsToRemoveByIt.push_back(std::find(EnemyBullet::enemyBullets.begin(), EnemyBullet::enemyBullets.end(), enemyBullet));
-            }
-        }
-        for (auto it : enemyBulletsToRemoveByIt) {
-            EnemyBullet::removeEnemyBullet(*it);
-        }
-        enemyBulletsToRemoveByIt.clear();
-        // debug << "\tAfter enemy bullets deletion" << std::endl;
-        for (auto bullet : Bullet::bullets) {
-            // if (bullet == nullptr) continue;
-            if (bullet->collided) {
-                bulletsToRemoveByIt.push_back(std::find(Bullet::bullets.begin(), Bullet::bullets.end(), bullet));
-            }
-        }
-        for (auto it : bulletsToRemoveByIt) {
-            Bullet::removeBullet(*it);
-        }
-        bulletsToRemoveByIt.clear();
+        EnemyBullet::enemyBullets.erase(
+            std::remove_if(
+                EnemyBullet::enemyBullets.begin(),
+                EnemyBullet::enemyBullets.end(),
+                [](const std::shared_ptr<EnemyBullet>& enemyBullet) {
+                    if (!enemyBullet) return true;
+                    if (enemyBullet->collided) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(enemyBullet.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            EnemyBullet::enemyBullets.end()
+        );
         // debug << "\tAfter bullets deletion" << std::endl;
         for (unsigned j=0; j<EnemyBullet::enemyBullets.size(); j++) {
             if (j >= EnemyBullet::enemyBullets.size()) break;
             std::shared_ptr<EnemyBullet> enemyBullet = EnemyBullet::enemyBullets[j];
             if (enemyBullet == nullptr) continue;
-            if (enemyBullet->collided) {
-                enemyBulletsToRemoveByIt.push_back(std::find(EnemyBullet::enemyBullets.begin(), EnemyBullet::enemyBullets.end(), enemyBullet));
-                continue;
-            }
+            if (enemyBullet->collided) continue;
             enemyBullet->move();
         }
-        for (auto it : enemyBulletsToRemoveByIt) {
-            EnemyBullet::removeEnemyBullet(*it);
-        }
-        enemyBulletsToRemoveByIt.clear();
+        EnemyBullet::enemyBullets.erase(
+            std::remove_if(
+                EnemyBullet::enemyBullets.begin(),
+                EnemyBullet::enemyBullets.end(),
+                [](const std::shared_ptr<EnemyBullet>& enemyBullet) {
+                    if (!enemyBullet) return true;
+                    if (enemyBullet->collided) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(enemyBullet.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            EnemyBullet::enemyBullets.end()
+        );
 
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)EnemyBullet::enemyBullets);
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Zombie::zombies);
@@ -401,19 +431,43 @@ int main(int argc, char** argv) {
                 zombie->shoot();
         // debug << "\tAfter zombies shooting" << std::endl;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Walker::walkers);
-        std::vector<std::vector<std::shared_ptr<Walker>>::iterator> walkersToRemoveByIt;
+        Walker::walkers.erase(
+            std::remove_if(
+                Walker::walkers.begin(),
+                Walker::walkers.end(),
+                [](const std::shared_ptr<Walker>& walker) {
+                    if (!walker) return true;
+                    if (walker->exploded) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(walker.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            Walker::walkers.end()
+        );
         for (auto walker : Walker::walkers) {
-            if (walker->exploded) {
-                walkersToRemoveByIt.push_back(std::find(Walker::walkers.begin(), Walker::walkers.end(), walker));
-                continue;
-            }
+            if (walker->exploded) continue;
             if (Walker::distribution(rng))
                 walker->move();
         }
-        for (auto it : walkersToRemoveByIt) {
-            Walker::removeWalker(*it);
-        }
-        walkersToRemoveByIt.clear();
+        Walker::walkers.erase(
+            std::remove_if(
+                Walker::walkers.begin(),
+                Walker::walkers.end(),
+                [](const std::shared_ptr<Walker>& walker) {
+                    if (!walker) return true;
+                    if (walker->exploded) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(walker.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            Walker::walkers.end()
+        );
         // debug << "\tAfter walkers" << std::endl;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Mine::mines);
         for (auto mine : Mine::mines)
@@ -441,29 +495,28 @@ int main(int argc, char** argv) {
         }
         // debug << "\tAfter cannons" << std::endl;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bomber::bombers);
-        std::vector<std::vector<std::shared_ptr<Bomber>>::iterator> bombersToRemoveByIt;
-        for (auto bomber : Bomber::bombers) {
-            if (bomber->exploded) {
-                bombersToRemoveByIt.push_back(std::find(Bomber::bombers.begin(), Bomber::bombers.end(), bomber));
-            }
-        }
-        for (auto it : bombersToRemoveByIt) {
-            Bomber::removeBomber(*it);
-        }
-        bombersToRemoveByIt.clear();
+        Bomber::bombers.erase(
+            std::remove_if(
+                Bomber::bombers.begin(),
+                Bomber::bombers.end(),
+                [](const std::shared_ptr<Bomber>& bomber) {
+                    if (!bomber) return true;
+                    if (bomber->exploded) {
+                        // Remove pawn from field before erasing
+                        field->erasePawn(bomber.get());
+                        return true;
+                    }
+                    return false;
+                }
+            ),
+            Bomber::bombers.end()
+        );
         for (unsigned j = 0; j < Bomber::bombers.size(); j++) {
             std::shared_ptr<Bomber> bomber = Bomber::bombers[j];
             if (bomber == nullptr) continue;
-            if (bomber->exploded) {
-                bombersToRemoveByIt.push_back(std::find(Bomber::bombers.begin(), Bomber::bombers.end(), bomber));
-                continue;
-            }
+            if (bomber->exploded) continue;
             bomber->move();
         }
-        for (auto it : bombersToRemoveByIt) {
-            Bomber::removeBomber(*it);
-        }
-        bombersToRemoveByIt.clear();
         // debug << "\tAfter bombers" << std::endl;
         try {
             Queen::queen->move();

--- a/dodas.cpp
+++ b/dodas.cpp
@@ -330,6 +330,7 @@ int main(int argc, char** argv) {
             // debug << "\tBullet " << j << ": " << Bullet::bullets[j] << std::endl;
         }
         #endif
+        std::vector<std::vector<std::shared_ptr<Bullet>>::iterator> bulletsToRemoveByIt;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bullet::bullets);
         for (unsigned j=0; j<Bullet::bullets.size(); j++) {
             if (j >= Bullet::bullets.size()) break;
@@ -337,7 +338,11 @@ int main(int argc, char** argv) {
             std::shared_ptr<Bullet> bullet = Bullet::bullets[j];
             if (bullet == nullptr) continue;
             // debug << "\t\tNot nullptr " << bullet << std::endl;
-            if (bullet->collided) continue;
+            if (bullet->collided) {
+                // debug << "\t\tCollided" << std::endl;
+                bulletsToRemoveByIt.push_back(std::find(Bullet::bullets.begin(), Bullet::bullets.end(), bullet));
+                continue;
+            }
             // debug << "\t\tNot collided" << std::endl;
             bullet->move();
             // debug << "\t\tAfter move" << std::endl;
@@ -345,45 +350,44 @@ int main(int argc, char** argv) {
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bullet::bullets);
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)EnemyBullet::enemyBullets);
         // debug << "\tAfter bullets" << std::endl;
+        std::vector<std::vector<std::shared_ptr<EnemyBullet>>::iterator> enemyBulletsToRemoveByIt;
         for (auto enemyBullet : EnemyBullet::enemyBullets) {
-            if (enemyBullet == nullptr) continue;
+            // if (enemyBullet == nullptr) continue;
             if (enemyBullet->collided) {
-                EnemyBullet::removeEnemyBullet(enemyBullet);
+                enemyBulletsToRemoveByIt.push_back(std::find(EnemyBullet::enemyBullets.begin(), EnemyBullet::enemyBullets.end(), enemyBullet));
             }
         }
+        for (auto it : enemyBulletsToRemoveByIt) {
+            EnemyBullet::removeEnemyBullet(*it);
+        }
+        enemyBulletsToRemoveByIt.clear();
         // debug << "\tAfter enemy bullets deletion" << std::endl;
         for (auto bullet : Bullet::bullets) {
-            if (bullet == nullptr) continue;
+            // if (bullet == nullptr) continue;
             if (bullet->collided) {
-                Bullet::removeBullet(bullet);
+                bulletsToRemoveByIt.push_back(std::find(Bullet::bullets.begin(), Bullet::bullets.end(), bullet));
             }
         }
+        for (auto it : bulletsToRemoveByIt) {
+            Bullet::removeBullet(*it);
+        }
+        bulletsToRemoveByIt.clear();
         // debug << "\tAfter bullets deletion" << std::endl;
         for (unsigned j=0; j<EnemyBullet::enemyBullets.size(); j++) {
             if (j >= EnemyBullet::enemyBullets.size()) break;
             std::shared_ptr<EnemyBullet> enemyBullet = EnemyBullet::enemyBullets[j];
             if (enemyBullet == nullptr) continue;
-            if (enemyBullet->collided) continue;
+            if (enemyBullet->collided) {
+                enemyBulletsToRemoveByIt.push_back(std::find(EnemyBullet::enemyBullets.begin(), EnemyBullet::enemyBullets.end(), enemyBullet));
+                continue;
+            }
             enemyBullet->move();
         }
-        // debug << "\tAfter enemy bullets" << std::endl;
-        
-        // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bullet::bullets);
-        // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)EnemyBullet::enemyBullets);
-        for (auto enemyBullet : EnemyBullet::enemyBullets) {
-            if (enemyBullet == nullptr) continue;
-            if (enemyBullet->collided) {
-                EnemyBullet::removeEnemyBullet(enemyBullet);
-            }
+        for (auto it : enemyBulletsToRemoveByIt) {
+            EnemyBullet::removeEnemyBullet(*it);
         }
-        // debug << "\tAfter enemy bullets deletion" << std::endl;
-        for (auto bullet : Bullet::bullets) {
-            if (bullet == nullptr) continue;
-            if (bullet->collided) {
-                Bullet::removeBullet(bullet);
-            }
-        }
-        // debug << "\tAfter bullets deletion" << std::endl;
+        enemyBulletsToRemoveByIt.clear();
+
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)EnemyBullet::enemyBullets);
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Zombie::zombies);
         for (auto zombie : Zombie::zombies) {
@@ -397,9 +401,19 @@ int main(int argc, char** argv) {
                 zombie->shoot();
         // debug << "\tAfter zombies shooting" << std::endl;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Walker::walkers);
-        for (auto walker : Walker::walkers)
+        std::vector<std::vector<std::shared_ptr<Walker>>::iterator> walkersToRemoveByIt;
+        for (auto walker : Walker::walkers) {
+            if (walker->exploded) {
+                walkersToRemoveByIt.push_back(std::find(Walker::walkers.begin(), Walker::walkers.end(), walker));
+                continue;
+            }
             if (Walker::distribution(rng))
                 walker->move();
+        }
+        for (auto it : walkersToRemoveByIt) {
+            Walker::removeWalker(*it);
+        }
+        walkersToRemoveByIt.clear();
         // debug << "\tAfter walkers" << std::endl;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Mine::mines);
         for (auto mine : Mine::mines)
@@ -427,11 +441,29 @@ int main(int argc, char** argv) {
         }
         // debug << "\tAfter cannons" << std::endl;
         // removeNullptrs((std::vector<std::shared_ptr<Entity>>&)Bomber::bombers);
+        std::vector<std::vector<std::shared_ptr<Bomber>>::iterator> bombersToRemoveByIt;
+        for (auto bomber : Bomber::bombers) {
+            if (bomber->exploded) {
+                bombersToRemoveByIt.push_back(std::find(Bomber::bombers.begin(), Bomber::bombers.end(), bomber));
+            }
+        }
+        for (auto it : bombersToRemoveByIt) {
+            Bomber::removeBomber(*it);
+        }
+        bombersToRemoveByIt.clear();
         for (unsigned j = 0; j < Bomber::bombers.size(); j++) {
             std::shared_ptr<Bomber> bomber = Bomber::bombers[j];
             if (bomber == nullptr) continue;
+            if (bomber->exploded) {
+                bombersToRemoveByIt.push_back(std::find(Bomber::bombers.begin(), Bomber::bombers.end(), bomber));
+                continue;
+            }
             bomber->move();
         }
+        for (auto it : bombersToRemoveByIt) {
+            Bomber::removeBomber(*it);
+        }
+        bombersToRemoveByIt.clear();
         // debug << "\tAfter bombers" << std::endl;
         try {
             Queen::queen->move();
@@ -707,7 +739,7 @@ void Bullet::move() {
     sista::Coordinates nextCoordinates = coordinates + directionMap[direction]*speed;
     if (field->isOutOfBounds(nextCoordinates)) {
         // debug << "Out of bounds" << std::endl;
-        Bullet::removeBullet(this);
+        this->collided = true; // Marking for removal
         // debug << "After remove" << std::endl;
         return;
     } else if (field->isFree(nextCoordinates)) {
@@ -776,7 +808,7 @@ void Bullet::move() {
             }
         }
         // debug << "\tAfter collision" << std::endl;
-        Bullet::removeBullet(this);
+        this->collided = true; // Marking for removal
         // debug << "\tAfter remove" << std::endl;
     }
 }
@@ -806,7 +838,7 @@ void EnemyBullet::removeEnemyBullet(EnemyBullet* enemyBullet) {
 void EnemyBullet::move() { // Pretty sure there's a segfault here
     sista::Coordinates nextCoordinates = coordinates + directionMap[direction]*speed;
     if (field->isOutOfBounds(nextCoordinates)) {
-        EnemyBullet::removeEnemyBullet(this);
+        this->collided = true; // Mark for removal
         return;
     } else if (field->isFree(nextCoordinates)) {
         field->movePawn(this, nextCoordinates);
@@ -846,7 +878,7 @@ void EnemyBullet::move() { // Pretty sure there's a segfault here
         } else if (hitten->type == Type::BOMBER) {
             Bomber::removeBomber((Bomber*)hitten);
         }
-        EnemyBullet::removeEnemyBullet(this);
+        this->collided = true; // Mark for removal
     }
 }
 
@@ -1059,7 +1091,7 @@ Wall::Wall() : Entity('=', {0, 0}, wallStyle, Type::WALL), strength(3) {}
 sista::ANSISettings Mine::mineStyle = {
     sista::ForegroundColor::MAGENTA,
     sista::BackgroundColor::BLACK,
-    sista::Attribute::BLINK   
+    sista::Attribute::BLINK
 };
 void Mine::removeMine(std::shared_ptr<Mine> mine) {
     Mine::mines.erase(std::find(Mine::mines.begin(), Mine::mines.end(), mine));
@@ -1088,6 +1120,8 @@ void Mine::trigger() {
     triggered = true;
     symbol = '%';
     settings.foregroundColor = sista::ForegroundColor::WHITE;
+    settings.attribute = sista::Attribute::BRIGHT;
+    field->rePrintPawn(this);
 }
 void Mine::explode() {
     for (int j=-2; j<=2; j++) {
@@ -1293,7 +1327,7 @@ void Bomber::move() {
         if (coordinates.x == 49) {
             this->explode();
         }
-        Bomber::removeBomber(this);
+        this->exploded = true; // Mark for removal
         return;
     }
     Entity* neighbor = (Entity*)field->getPawn(nextCoordinates);
@@ -1331,7 +1365,7 @@ void Bomber::move() {
     } else if (neighbor->type == Type::BOMBER) {
         return;
     }
-    Bomber::removeBomber(this);
+    this->exploded = true; // Mark for removal
 }
 void Bomber::explode() {
     for (int j=-2; j<=2; j++) {
@@ -1405,7 +1439,7 @@ void Walker::move() { // Walkers mostly move horizontally because they only rare
         if (coordinates.x == 0) { // Touchdown, the player loses all the ammonitions
             Player::player->ammonitions = 0;
             this->explode();
-            Walker::removeWalker(this);
+            this->exploded = true; // Mark for removal
             return;
         } else { // Touched bottom limit, we can use pacman effect which clearly can be used by walkers
             try {
@@ -1426,7 +1460,7 @@ void Walker::move() { // Walkers mostly move horizontally because they only rare
         end = true;
     } else if (neighbor->type == Type::BULLET) {
         Bullet::removeBullet((Bullet*)neighbor);
-        Walker::removeWalker(this);
+        this->exploded = true; // Mark for removal
     } else if (neighbor->type == Type::WALL) {
         Wall* wall = (Wall*)neighbor;
         if (wall->strength == 0) {

--- a/dodas.cpp
+++ b/dodas.cpp
@@ -1395,8 +1395,7 @@ void Bomber::move() {
         field->rePrintPawn(wall); // It will be reprinted in the next frame and then removed because of (strength == 0)
         explode();
     } else if (neighbor->type == Type::PLAYER) {
-        // lose();
-        end = true;
+        return; // The player keeps the bomber in place
     } else if (neighbor->type == Type::BULLET) {
         ((Bullet*)neighbor)->collided = true;
     } else if (neighbor->type == Type::ENEMYBULLET) {

--- a/dodas.hpp
+++ b/dodas.hpp
@@ -14,11 +14,20 @@
 
 #define START_AMMONITION 10
 
-#define DEBUG 0
+#define DEBUG 1
 #define INTRO 1
 #define SCAN_FOR_NULLPTRS 0
 #define VERSION "1.0.0-alpha.1"
 #define DATE "2025-08-26"
+
+#if DEBUG
+    #undef START_AMMONITION
+        #define START_AMMONITION 500
+    #undef INTRO
+        #define INTRO 0
+    #undef SCAN_FOR_NULLPTRS
+        #define SCAN_FOR_NULLPTRS 1
+#endif
 
 #define WIN_API_MUSIC_DELAY 80
 #define REPOPULATE 127 // The number of frame before the whole sista::Field is emptied and repopulated
@@ -214,6 +223,7 @@ class Bomber : public Entity { // Bombers go towards the enemies and explode whe
 public:
     static sista::ANSISettings bomberStyle;
     static std::vector<std::shared_ptr<Bomber>> bombers;
+    bool exploded = false;
 
     Bomber();
     Bomber(sista::Coordinates);
@@ -230,6 +240,7 @@ public:
     static sista::ANSISettings walkerStyle;
     static std::vector<std::shared_ptr<Walker>> walkers;
     static std::bernoulli_distribution distribution; // The walker moves a cell every walkerSpeed frames, on average
+    bool exploded = false;
 
     Walker();
     Walker(sista::Coordinates);


### PR DESCRIPTION
After having debugged for long, I concluded that the best solution for the recurrent problem is the one included in this pull request.

The only paradigm that makes sense for erasing elements is the `container.erase(std::remove_if())` one.

```c++
EnemyBullet::enemyBullets.erase(
    std::remove_if(
        EnemyBullet::enemyBullets.begin(),
        EnemyBullet::enemyBullets.end(),
        [](const std::shared_ptr<EnemyBullet>& enemyBullet) {
            if (!enemyBullet) return true;
            if (enemyBullet->collided) {
                // Remove pawn from field before erasing
                field->erasePawn(enemyBullet.get());
                return true;
            }
            return false;
        }
    ),
    EnemyBullet::enemyBullets.end()
);
```